### PR TITLE
Fix for issue #3 and #5: Enums, RPCs, Player Counts

### DIFF
--- a/Assets/Source/Game/SGameMan.cs
+++ b/Assets/Source/Game/SGameMan.cs
@@ -377,7 +377,7 @@ public class SGameMan : MonoBehaviour {
 	
 		Debug.Log ("End of match.");
 		
-		networkView.RPC ("TheEnd", RPCMode.All, gameState);
+		networkView.RPC ("TheEnd", RPCMode.All, (int)gameState);
 		
 		Debug.Log ("Match status: " + gameState);
 		

--- a/Assets/Source/ServerC.cs
+++ b/Assets/Source/ServerC.cs
@@ -221,7 +221,7 @@ public class ServerC : MonoBehaviour {
 					
 						GUILayout.Space (5);
 						string serverName = "Name: " + element.gameName;
-						string connectedPlayers = element.connectedPlayers + " out of " + element.playerLimit + " players connected.";
+						string connectedPlayers = (element.connectedPlayers - 1) + " out of " + element.playerLimit + " players connected.";
 						
 						GUILayout.Box ("", divider, GUILayout.Height (2));
 						GUILayout.Label (serverName);


### PR DESCRIPTION
Fix for issue #3 and issue #5: Updated parameters on "TheEnd" call to
cast the enum type as an int before the RPC call; I did some Googling
and it seems like you can't pass enums in this way and this is the best
solution to resolve the error. I also updated the counter (via a
decrement) in the ServerC GUI. If you accept this pull request then you
can close these two bugs in the issues list.
